### PR TITLE
Create Typescript type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.4",
   "description": "A flexible pool of promises that can be awaited and executed at a chosen level of concurrency",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "babel src -d lib",
+    "build": "babel src -d lib && cp src/index.d.ts lib/index.d.ts",
     "prepublish": "yarn run build",
     "test": "jest"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,26 @@
+declare module 'async-promise-pool' {
+  type PromiseProducer = () => Promise<any>;
+  type Deferred = {
+    resolve: (value: any) => void,
+    reject: (error: unknown) => void,
+    promise: Promise<any>
+  };
+  type Options = { concurrency?: number };
+
+  class PromisePool {
+    queue: PromiseProducer[];
+    pool: Promise<any>[];
+    results: any[];
+    final: Deferred;
+    error?: Error;
+    concurrency: number;
+
+    constructor(options: Options);
+
+    next(): Promise<any>;
+    add(promiseProducer: PromiseProducer): void;
+    all(): Promise<any>;
+  }
+
+  export default PromisePool;
+}


### PR DESCRIPTION
#23 

These are basic types. A potential future improvement might be making the PromisePool class a generic (so the promise resolve value is explicitly typed), but I wasn't able to get that working at this point.

I added the file to `./src` and just copied it on build to `./lib` since it seems like `./lib` is only for built files. Happy to remove it from `./src` if that makes sense.