### PR TITLE
Add config to return promise from add()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://badge.fury.io/js/async-promise-pool.svg)](https://badge.fury.io/js/async-promise-pool) [![CircleCI](https://circleci.com/gh/tommoor/promise-pool.svg?style=svg)](https://circleci.com/gh/tommoor/promise-pool) 
+[![npm version](https://badge.fury.io/js/async-promise-pool.svg)](https://badge.fury.io/js/async-promise-pool) [![CircleCI](https://circleci.com/gh/tommoor/promise-pool.svg?style=svg)](https://circleci.com/gh/tommoor/promise-pool)
 
 # Promise Pool
 
@@ -6,19 +6,43 @@ Promise pool is a small, dependency free, library to manage the
 concurrent resolution of any number of promises. It is particularly useful
 when the promises are not all available upfront.
 
+## Options
+
+Options are passed to the `PromisePool` constructor:
+```javascript
+const PromisePool = require("async-promise-pool");
+const pool = new PromisePool(options);
+```
+
+The `options` object allows you to set the following:
+
+### `concurrency`
+Enables you to choose how many promises will run at once
+
+Default: no limit to concurrency (i.e. `Number.MAX_VALUE`)
+
+### `accessIndividualPromises`
+If set to `true`, `pool.add()` passes through the passed promise, out to the caller (see example below)
+
+Default: `false`
+
 ## Example Usage
 ```javascript
 const PromisePool = require("async-promise-pool");
 
-// concurrency is the only option for PromisePool and enables you to 
-// choose how many promises will run at once
-const pool = new PromisePool({ concurrency: 3 });
+const pool = new PromisePool({
+  // Only allow 3 unresolved promises at a time
+  concurrency: 3,
+
+  // Pass through the promise passed to pool.add() to the caller
+  accessIndividualPromises: true
+});
 
 // elsewhere add functions to the pool that produce promises. We use
 // functions here to prevent the promises from immediately executing.
-pool.add(() => thingThatReturnsAPromise());
+const resolvedValue = await pool.add(() => thingThatReturnsAPromise());
 
-// you can await pool.all to ensure that all promises in the pool are 
+// you can await pool.all to ensure that all promises in the pool are
 // resolved before continuing.
 await pool.all();
 ```

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -90,6 +90,14 @@ describe("PromisePool", () => {
     expect(results.length).toBe(3);
   });
 
+  it("should return promise from .add() if accessIndividualPromises is true", async () => {
+    const pool = new PromisePool({ accessIndividualPromises: true });
+    const result1 = await pool.add(promiseProducer);
+    const result2 = await pool.add(promiseProducer);
+    expect(result1).toBe("success");
+    expect(result2).toBe("success");
+  })
+
   it("should throw if .all fails", async () => {
     const pool = new PromisePool({ concurrency: 2 });
     let error;


### PR DESCRIPTION
If the user sets the `accessIndividualPromises` option, return a promise from `.add()`.

I added this as an off-by-default config option because otherwise this would be a breaking change. If any of the promises reject, this would cause any existing code to have an uncaught rejection, which could throw an error depending on the runtime settings.

Example:
```js
const pool = new PromisePool({ accessIndividualPromises: true });
const response = await promise.add(() => fetch(...))
```

This config option name was all I could come up with, but there's probably something simpler and more terse that would be better - open to suggestions.